### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The Filecoin Hyperspace testnet is a stable testnet with fewer resets intended f
   - These endpoints are limited to all read-only Filecoin JSON RPC API calls + `MPoolPush` (for sending already signed messages)
   - **Glif Nodes RPC:**
     - https://api.hyperspace.node.glif.io/rpc/v1
-    - web socket endpoint: wss://wss.hyperspace.node.glif.io/apigw/lotus/rpc/v1
+    - web socket endpoint: wss://wss.hyperspace.node.glif.io/apigw/lotus
   - **ChainStack RPC:**
     - https://filecoin-hyperspace.chainstacklabs.com/rpc/v0
     - web socket endpoint: wss://ws-filecoin-hyperspace.chainstacklabs.com/rpc/v0


### PR DESCRIPTION
I propose the change from `wss://wss.hyperspace.node.glif.io/apigw/lotus/rpc/v1` to `wss://wss.hyperspace.node.glif.io/apigw/lotus`.

When running a lotus lite node it only works with the latter  `FULLNODE_API_INFO=wss://wss.hyperspace.node.glif.io/apigw/lotus lotus daemon --lite`

In this issue (https://github.com/filecoin-project/lotus/issues/10099) you can see that this is the intended wss that should be used when running a lotus lite node.

Please correct me if I should have changed it elsewhere. I can also revert my changes and add a new bullet point to indicate that when using a GLIF node to run lotus lite one should use the wss without the `rpc/v1` part:

```
- **RPC - Public Endpoints**:
  - These endpoints are limited to all read-only Filecoin JSON RPC API calls + `MPoolPush` (for sending already signed messages)
  - **Glif Nodes RPC:**
    - https://api.hyperspace.node.glif.io/rpc/v1
    - web socket endpoint: wss://wss.hyperspace.node.glif.io/apigw/lotus/rpc/v1
    - *NOTE:* When using the web socket endpoint to run a lite node please use `wss://wss.hyperspace.node.glif.io/apigw/lotus`
```

More details on the Filecoin's slack  - https://filecoinproject.slack.com/archives/C04JEJB82RY/p1674398487957749